### PR TITLE
Fix typo in matching.cu

### DIFF
--- a/cudaSiftH.cu
+++ b/cudaSiftH.cu
@@ -80,7 +80,9 @@ void ExtractSift(SiftData &siftData, CudaImage &img, int numOctaves, double init
     ExtractSiftLoop(siftData, lowImg, numOctaves, 0.0f, thresh, lowestScale*2.0f, 1.0f, memoryTmp, memorySub + height*iAlignUp(width, 128));
     safeCall(cudaMemcpyFromSymbol(&siftData.numPts, d_PointCounter, sizeof(int)));
     siftData.numPts = (siftData.numPts<siftData.maxPts ? siftData.numPts : siftData.maxPts);
-    RescalePositions(siftData, 0.5f);
+    if (siftData.numPts > 0) {
+      RescalePositions(siftData, 0.5f);
+    }
   }
   
   safeCall(cudaFree(memoryTmp));

--- a/matching.cu
+++ b/matching.cu
@@ -114,7 +114,7 @@ __global__ void FindMaxCorr(float *corrData, SiftPoint *sift1, SiftPoint *sift2,
     sift1[p1].score = maxScore[ty*16];
   if (tx==7)
     // sift1[p1].ambiguity = maxScor2[ty*16] / (maxScore[ty*16] + 1e-6);
-    sift1[p1].ambiguity = (1 - maxScor[ty*16]) / (1 - maxScore2[ty*16] + 1e-6);
+    sift1[p1].ambiguity = (1 - maxScore[ty*16]) / (1 - maxScor2[ty*16] + 1e-6);
   if (tx==8)
     sift1[p1].match = maxIndex[ty*16];
   if (tx==9)


### PR DESCRIPTION
I found some typos in `matching.cu`. After fixing the typos, I could compile and run pycudasift. Thanks for sharing a wrapper project for cudasift.